### PR TITLE
Feature/email service infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Example:
 This table maps the `messageId` to a file object on AWS S3. It also contains the default *subject* line for the email message. The default *subject* may be overridden if there is a `subject` in the message `context`.
 
 ### Item Attributes
-- `messageId`: String, slug-style 
-- `subject`: String, the default subject line for the email message
-- `templateFile`: String, the name of the template file
+- `MessageId`: String, slug-style 
+- `Subject`: String, the default subject line for the email message
+- `TemplateFile`: String, the name of the template file
 
 ### Keys
 - **Partition Key**: `messageId`
@@ -78,17 +78,16 @@ none
 This table is a record of email messages sent by the **Email Service**
 
 ### Item Attributes
-- `id` : UUID
-- `timestamp`: Int64
-- `messageSent`: String(`timestamp`)
-- `recipient`: String(email address)
-- `messageId`: String
-- `context`: Map of String (name -> value)
+- `Id` : UUID
+- `Timestamp`: Int64
+- `MessageSent`: String(`timestamp`)
+- `Recipient`: String(email address)
+- `MessageId`: String
+- `Context`: Map of String (name -> value)
 
 ### Keys
-- **Partition Key**: `id`
-- **Sort Key**: `messageId`
+- **Partition Key**: `Id`
+- **Sort Key**: `MessageId`
 
 ### Search Indexes
-- **RecipientIndex**: `recipient` + `messageId`
-
+- **RecipientMessageIdIndex**: `Recipient` + `MessageId`

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -1,0 +1,81 @@
+resource "aws_dynamodb_table" "email_message_templates_table" {
+  name           = "${var.environment_name}-email-message-templates-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "MessageId"
+  range_key      = "TemplateFile"
+
+  attribute {
+    name = "MessageId"
+    type = "S"
+  }
+
+  attribute {
+    name = "TemplateFile"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name"         = "${var.environment_name}-email-message-templates-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "name"         = "${var.environment_name}-email-message-templates-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "service_name" = var.service_name
+    },
+  )
+
+}
+
+resource "aws_dynamodb_table" "email_message_log_table" {
+  name           = "${var.environment_name}-email-message-log-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "Id"
+  range_key      = "MessageId"
+
+  attribute {
+    name = "Id"
+    type = "S"
+  }
+
+  attribute {
+    name = "MessageId"
+    type = "S"
+  }
+
+  attribute {
+    name = "Recipient"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name               = "RecipientMessageIdIndex"
+    hash_key           = "Recipient"
+    range_key          = "MessageId"
+    projection_type    = "ALL"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name"         = "${var.environment_name}-email-message-log-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "name"         = "${var.environment_name}-email-message-log-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+      "service_name" = var.service_name
+    },
+  )
+
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -84,9 +84,40 @@ data "aws_iam_policy_document" "service_iam_policy_document" {
     resources = ["arn:aws:ssm:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.environment_name}/${var.service_name}/*"]
   }
 
+  statement {
+    sid = "EmailServiceSESPermissions"
+    effect  = "Allow"
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail",
+    ]
+    resources = ["*"]
+  }
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.email_service_queue_policy_document.json,
+    data.aws_iam_policy_document.email_service_queue_kms_key_policy_document.json,
+    data.aws_iam_policy_document.email_templates_s3_bucket_policy_document.json
+  ]
 }
 
 data "aws_iam_policy_document" "email_templates_s3_bucket_policy_document" {
+  statement {
+    sid = "EmailTemplatesS3Permission"
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:s3:::pennsieve-${local.email_templates_bucket_name}",
+      "arn:aws:s3:::pennsieve-${local.email_templates_bucket_name}/*",
+    ]
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectAttributes",
+      "s3:ListBucket"
+    ]
+  }
+
   statement {
     sid    = "ForceSSLOnlyAccess"
     effect = "Deny"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -85,3 +85,30 @@ data "aws_iam_policy_document" "service_iam_policy_document" {
   }
 
 }
+
+data "aws_iam_policy_document" "email_templates_s3_bucket_policy_document" {
+  statement {
+    sid    = "ForceSSLOnlyAccess"
+    effect = "Deny"
+
+    resources = [
+      "arn:aws:s3:::pennsieve-${local.email_templates_bucket_name}",
+      "arn:aws:s3:::pennsieve-${local.email_templates_bucket_name}/*",
+    ]
+
+    actions = [
+      "s3:*",
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      values   = ["false"]
+      variable = "aws:SecureTransport"
+    }
+  }
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -97,7 +97,8 @@ data "aws_iam_policy_document" "service_iam_policy_document" {
   source_policy_documents = [
     data.aws_iam_policy_document.email_service_queue_policy_document.json,
     data.aws_iam_policy_document.email_service_queue_kms_key_policy_document.json,
-    data.aws_iam_policy_document.email_templates_s3_bucket_policy_document.json
+    data.aws_iam_policy_document.email_templates_s3_bucket_policy_document.json,
+    data.aws_iam_policy_document.email_service_dynamodb_policy_document.json
   ]
 }
 
@@ -189,5 +190,30 @@ data "aws_iam_policy_document" "email_service_queue_policy_document" {
       type        = "Service"
       identifiers = ["events.amazonaws.com"]
     }
+  }
+}
+
+data "aws_iam_policy_document" "email_service_dynamodb_policy_document" {
+  statement {
+    sid = "EmailServiceLambdaDynamoDBPermissions"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:BatchGetItem",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:PartiQLSelect"
+    ]
+
+    resources = [
+      aws_dynamodb_table.email_message_templates_table.arn,
+      "${aws_dynamodb_table.email_message_templates_table.arn}/*",
+      aws_dynamodb_table.email_message_log_table.arn,
+      "${aws_dynamodb_table.email_message_log_table.arn}/*"
+    ]
   }
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -112,3 +112,51 @@ data "aws_iam_policy_document" "email_templates_s3_bucket_policy_document" {
     }
   }
 }
+
+data "aws_iam_policy_document" "email_service_queue_kms_key_policy_document" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.terraform_remote_state.account.outputs.aws_account_id}:root"]
+    }
+  }
+
+  statement {
+    sid    = "Enable Cloudwatch Event Permissions"
+    effect = "Allow"
+
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "email_service_queue_policy_document" {
+  statement {
+    effect    = "Allow"
+    actions   = [
+      "sqs:ReceiveMessage",
+      "sqs:SendMessage",
+      "sqs:DeleteMessage",
+    ]
+    resources = [aws_sqs_queue.email_service_queue.arn]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -1,0 +1,11 @@
+resource "aws_kms_alias" "email_service_sqs_kms_key_alias" {
+  name          = "alias/${var.environment_name}-${var.service_name}-queue-key-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  target_key_id = aws_kms_key.email_service_sqs_kms_key.key_id
+}
+
+resource "aws_kms_key" "email_service_sqs_kms_key" {
+  description             = "${var.environment_name}-${var.service_name}-queue-key-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.email_service_queue_kms_key_policy_document.json
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,6 +1,6 @@
 resource "aws_lambda_function" "service_lambda" {
   description   = "A Serverless Service that sends emails for the Pennsieve platform"
-  function_name = "${var.environment_name}-${var.service_name}-service-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  function_name = "${var.environment_name}-${var.service_name}-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
   handler       = "bootstrap"
   runtime       = "provided.al2"
   architectures = ["arm64"]

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,51 @@
+## Create Dataset Assets S3 Bucket
+resource "aws_s3_bucket" "email_templates_s3_bucket" {
+  bucket = local.email_templates_bucket_name
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = merge(
+    local.common_tags,
+    {
+      "Name"         = local.email_templates_bucket_name
+      "name"         = local.email_templates_bucket_name
+      "service_name" = var.service_name
+      "tier"         = "s3"
+    },
+  )
+}
+
+resource "aws_s3_bucket_policy" "email_templates_s3_bucket_policy" {
+  bucket = aws_s3_bucket.email_templates_s3_bucket.bucket
+  policy = data.aws_iam_policy_document.email_templates_s3_bucket_policy_document.json
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "email_templates_s3_bucket_encryption" {
+  bucket = aws_s3_bucket.email_templates_s3_bucket.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = local.encryption_algorithm
+    }
+  }
+}
+
+resource "aws_s3_bucket_logging" "email_templates_s3_bucket_logging" {
+  bucket = aws_s3_bucket.email_templates_s3_bucket.id
+
+  target_bucket = data.terraform_remote_state.region.outputs.logs_s3_bucket_id
+  target_prefix = "${var.environment_name}/${local.email_templates}/s3/"
+}
+
+resource "aws_s3_bucket_cors_configuration" "email_templates_s3_bucket_cors" {
+  bucket = aws_s3_bucket.email_templates_s3_bucket.bucket
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3000
+  }
+}

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -1,0 +1,24 @@
+resource "aws_sqs_queue" "email_service_queue" {
+  name                       = "${var.environment_name}-${var.service_name}-queue-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  delay_seconds              = 5
+  max_message_size           = 262144
+  message_retention_seconds  = 86400
+  kms_master_key_id          = "alias/${var.environment_name}-${var.service_name}-queue-key-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 30
+  redrive_policy             = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.email_service_deadletter_queue.arn}\",\"maxReceiveCount\":3}"
+}
+
+resource "aws_sqs_queue" "email_service_deadletter_queue" {
+  name                      = "${var.environment_name}-${var.service_name}-deadletter-queue-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  delay_seconds             = 5
+  kms_master_key_id         = "alias/${var.environment_name}-${var.service_name}-queue-key-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  max_message_size          = 262144
+  message_retention_seconds = 86400
+  receive_wait_time_seconds = 10
+}
+
+resource "aws_sqs_queue_policy" "email_service_sqs_queue_policy" {
+  queue_url = aws_sqs_queue.email_service_queue.id
+  policy    = data.aws_iam_policy_document.email_service_queue_policy_document.json
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,6 +20,11 @@ locals {
   domain_name = data.terraform_remote_state.account.outputs.domain_name
   hosted_zone = data.terraform_remote_state.account.outputs.public_hosted_zone_id
 
+  email_templates                    = "email-templates"
+  email_templates_bucket_name        = "pennsieve-${var.environment_name}-${local.email_templates}-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  email_templates_logs_target_prefix = "${var.environment_name}/${local.email_templates}/s3/"
+
+  encryption_algorithm = "AES256"
   common_tags = {
     aws_account      = var.aws_account
     aws_region       = data.aws_region.current_region.name


### PR DESCRIPTION
Adds infrastructure for:
- S3 buckets for holding email templates
- SQS queue for "send email message" requests
- SES access for sending emails
- DynamoDB tables for holding service metadata and message send logs