### PR TITLE
Align SQS visibility timeout with queue lambda timeout (dev deploy fix)

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -5,10 +5,12 @@ resource "aws_lambda_function" "queue_lambda" {
   runtime       = "provided.al2"
   architectures = ["arm64"]
   role          = aws_iam_role.queue_lambda_role.arn
-  timeout       = 300
-  memory_size   = 128
-  s3_bucket     = var.lambda_bucket
-  s3_key        = "${var.service_name}/${var.service_name}-${var.image_tag}.zip"
+  # Sending an email is quick; 150s is generous headroom. The SQS queue's
+  # visibility timeout (sqs.tf) must stay greater than this — keep them in sync.
+  timeout     = 150
+  memory_size = 128
+  s3_bucket   = var.lambda_bucket
+  s3_key      = "${var.service_name}/${var.service_name}-${var.image_tag}.zip"
 
   vpc_config {
     subnet_ids         = tolist(data.terraform_remote_state.vpc.outputs.private_subnet_ids)

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -1,11 +1,16 @@
 resource "aws_sqs_queue" "email_service_queue" {
-  name                       = "${var.environment_name}-${var.service_name}-queue-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  delay_seconds              = 5
-  max_message_size           = 262144
-  message_retention_seconds  = 86400
-  kms_master_key_id          = "alias/${var.environment_name}-${var.service_name}-queue-key-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  receive_wait_time_seconds  = 10
-  visibility_timeout_seconds = 30
+  name                      = "${var.environment_name}-${var.service_name}-queue-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  delay_seconds             = 5
+  max_message_size          = 262144
+  message_retention_seconds = 86400
+  kms_master_key_id         = "alias/${var.environment_name}-${var.service_name}-queue-key-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
+  receive_wait_time_seconds = 10
+  # Must be > the queue lambda's function timeout (150s in lambda.tf), or the
+  # Lambda event source mapping is rejected: "Queue visibility timeout is less
+  # than Function timeout". Set to 3x the lambda timeout so a near-timeout
+  # invocation isn't redelivered while still running. Update both together if
+  # either changes.
+  visibility_timeout_seconds = 450
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.email_service_deadletter_queue.arn
     maxReceiveCount     = 3


### PR DESCRIPTION
## Problem
Dev deploy failed creating the Lambda event source mapping:

```
InvalidParameterValueException: Queue visibility timeout: 30 seconds is less
than Function timeout: 300 seconds
```

AWS requires the SQS queue's visibility timeout ≥ the consuming Lambda's function timeout.

## Change
Aligned to sensible values (not just clearing the floor):
- **queue lambda `timeout`: 300 → 150s** — sending an email is quick; 150s is generous headroom.
- **queue `visibility_timeout_seconds`: 30 → 450s** — 3× the lambda timeout, so a near-timeout invocation isn't redelivered while still running.

Comments on both resources cross-reference each other to prevent future drift.

Branched off current `main` (post-#7 merge), so it has the correct terraform baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)