### PR TITLE
Make Scala client releases intentional and tag-driven

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,20 @@
 #!groovy
 
 // CI for the email-service: the Go queue lambda (test, publish artifact, deploy
-// via service-deploy) and the Scala producer client in client-scala/ (test, and
-// publish to Nexus on main).
+// via service-deploy) and the Scala producer client in client-scala/ (test +
+// publish to Nexus).
 //
-// RELEASE_VERSION (optional) publishes the Scala client as a release artifact
-// (com.pennsieve:email-client-scala) at that version; left blank, main builds
-// publish a -SNAPSHOT. Nexus credentials are bound from the Jenkins credential
-// 'pennsieve-nexus-ci-login' around every sbt invocation (resolve + publish),
-// matching pennsieve-api. Without them sbt hits Nexus unauthenticated and fails
-// with "Server redirected too many times".
+// Scala client versioning (com.pennsieve:email-client-scala) — releases are
+// intentional, driven by git tags:
+//   * Tag build (vX.Y.Z)        -> publish release X.Y.Z to maven-releases.
+//   * main-branch build         -> publish next-minor-SNAPSHOT to maven-snapshots
+//                                   (e.g. latest tag v1.2.0 -> 1.3.0-SNAPSHOT).
+//   * other branches            -> test only, no publish.
+//
+// Nexus credentials are bound from the Jenkins credential 'pennsieve-nexus-ci-login'
+// around every sbt invocation (resolve + publish), matching pennsieve-api.
+// Without them sbt hits Nexus unauthenticated and fails with
+// "Server redirected too many times".
 
 def pennsieveNexusCreds = usernamePassword(
     credentialsId: 'pennsieve-nexus-ci-login',
@@ -17,15 +22,26 @@ def pennsieveNexusCreds = usernamePassword(
     passwordVariable: 'PENNSIEVE_NEXUS_PW'
 )
 
-properties([
-  parameters([
-    string(
-      name: 'RELEASE_VERSION',
-      defaultValue: '',
-      description: 'If set (e.g. 1.2.3), publish the Scala client as a release at this version. Blank = SNAPSHOT.'
-    )
-  ])
-])
+// scalaClientVersion computes the version to publish:
+//   - on a vX.Y.Z tag  -> "X.Y.Z"            (release)
+//   - otherwise        -> "X.(Y+1).0-SNAPSHOT" from the latest vX.Y.Z tag,
+//                         or "0.1.0-SNAPSHOT" if there are no tags yet.
+def scalaClientVersion(tagName) {
+  if (tagName?.trim() && tagName ==~ /^v\d+\.\d+\.\d+$/) {
+    return tagName.substring(1) // strip leading 'v'
+  }
+  def latest = sh(
+    returnStdout: true,
+    script: "git tag --list 'v*' --sort=-v:refname | head -1"
+  ).trim()
+  if (!latest) {
+    return "0.1.0-SNAPSHOT"
+  }
+  def m = (latest =~ /^v(\d+)\.(\d+)\.(\d+)$/)
+  def major = m[0][1] as int
+  def minor = m[0][2] as int
+  return "${major}.${minor + 1}.0-SNAPSHOT"
+}
 
 ansiColor('xterm') {
   node('executor') {
@@ -34,11 +50,14 @@ ansiColor('xterm') {
 
   def authorName  = sh(returnStdout: true, script: 'git --no-pager show --format="%an" --no-patch')
   def isMain    = env.BRANCH_NAME == "main"
+  def isTag     = (env.TAG_NAME?.trim()) ? true : false
   def serviceName = env.JOB_NAME.tokenize("/")[1]
   def isRealService = serviceName != "template-serverless-service"
 
   def commitHash  = sh(returnStdout: true, script: 'git rev-parse HEAD | cut -c-7').trim()
   def imageTag    = "${env.BUILD_NUMBER}-${commitHash}"
+
+  def scalaVersion = scalaClientVersion(env.TAG_NAME)
 
   try {
     stage("Run Tests") {
@@ -59,23 +78,23 @@ ansiColor('xterm') {
       }
     }
 
-    if(isMain) {
-      stage ('Build and Push') {
-        sh "IMAGE_TAG=${imageTag} make publish"
-      }
-
-      // Publish the Scala client to Nexus. With RELEASE_VERSION set it's a
-      // release; otherwise a SNAPSHOT (version defaults to bootstrap-SNAPSHOT).
+    // Publish the Scala client. A vX.Y.Z tag publishes the release X.Y.Z; a main
+    // build publishes the next-minor -SNAPSHOT. Other branches don't publish.
+    if (isTag || isMain) {
       stage("Publish Scala client") {
         withCredentials([pennsieveNexusCreds]) {
           dir("client-scala") {
-            if (params.RELEASE_VERSION?.trim()) {
-              sh "sbt -batch -Dversion=${params.RELEASE_VERSION} publish"
-            } else {
-              sh "sbt -batch publish"
-            }
+            sh "sbt -batch -Dversion=${scalaVersion} publish"
           }
         }
+      }
+    }
+
+    // The Go lambda is built/published/deployed only on main (a tag is a library
+    // release, not a service deploy).
+    if (isMain) {
+      stage ('Build and Push') {
+        sh "IMAGE_TAG=${imageTag} make publish"
       }
 
       if(isRealService) {

--- a/client-scala/README.md
+++ b/client-scala/README.md
@@ -59,18 +59,33 @@ com.pennsieve %% email-client-scala % <version>   // Scala 2.13
 Published to the Pennsieve Nexus (`nexus.pennsieve.cc`), same as pennsieve-api,
 so a consumer that already resolves Pennsieve artifacts needs no extra resolver.
 
-## Building & publishing
+## Versioning & publishing
+
+Releases are **intentional and tag-driven**. CI (the email-service `Jenkinsfile`)
+publishes to Nexus as follows:
+
+| Trigger | Publishes | Where |
+|---|---|---|
+| **git tag `vX.Y.Z`** (or a GitHub Release from it) | release `X.Y.Z` | `maven-releases` |
+| **merge to `main`** | next-minor `-SNAPSHOT` (latest `v1.2.0` → `1.3.0-SNAPSHOT`) | `maven-snapshots` |
+| other branches | nothing (test only) | — |
+
+Consumers pin a released semver (e.g. `com.pennsieve %% email-client-scala % "1.2.0"`),
+never a SNAPSHOT.
+
+**To cut a release:** tag the commit `vX.Y.Z` and push the tag (or publish a
+GitHub Release); CI publishes `X.Y.Z`. Use `v`-prefixed tags to match the house
+convention (e.g. pennsieve-go-core); the artifact version drops the `v`.
 
 ```bash
+# local builds (version comes from -Dversion; bare publish is a dev SNAPSHOT)
 sbt test                       # compile + run the contract tests
-sbt publish                    # publish a -SNAPSHOT to Nexus
-sbt -Dversion=1.2.3 publish    # publish release 1.2.3 to Nexus
+sbt -Dversion=1.2.3 publish    # publish 1.2.3 (needs Nexus creds in env)
 ```
 
 Publishing requires `PENNSIEVE_NEXUS_USER` / `PENNSIEVE_NEXUS_PW` in the
-environment (the Jenkins executor provides them). CI publishes from the
-email-service `Jenkinsfile`: every `main` build publishes a SNAPSHOT; pass the
-`RELEASE_VERSION` job parameter to cut a release.
+environment (the Jenkins executor provides them via the `pennsieve-nexus-ci-login`
+credential).
 
 ## Keeping in sync with the Go client
 

--- a/client-scala/build.sbt
+++ b/client-scala/build.sbt
@@ -12,9 +12,10 @@ ThisBuild / scalaVersion := "2.13.16"
 // Mirrors pennsieve-api (set in both build.sbt and project/plugins.sbt).
 ThisBuild / useCoursier := false
 
-// Version is injected by CI (sbt -Dversion=1.2.3 publish); local/dev builds are
-// snapshots. Mirrors pennsieve-api.
-ThisBuild / version := sys.props.get("version").getOrElse("bootstrap-SNAPSHOT")
+// CI always injects the version (sbt -Dversion=X.Y.Z publish): a vX.Y.Z tag
+// publishes the release X.Y.Z; a main build publishes the next-minor -SNAPSHOT
+// (see the Jenkinsfile). The fallback only applies to a bare local `sbt publish`.
+ThisBuild / version := sys.props.get("version").getOrElse("0.0.0-SNAPSHOT")
 
 // Publish to the Pennsieve Nexus, same as pennsieve-api. Credentials come from
 // the environment (the Jenkins executor provides them) — no creds in the repo.


### PR DESCRIPTION
## Why
The Scala client defaulted to publishing a `bootstrap-SNAPSHOT` on every `main` build, with a real version only when the `RELEASE_VERSION` param was set. So the normal output was a SNAPSHOT — which we don't consume in projects. Releases should be **intentional**.

## New behavior (tag-driven)
| Trigger | Publishes | Where |
|---|---|---|
| git tag `vX.Y.Z` | release `X.Y.Z` | `maven-releases` |
| merge to `main` | next-minor `-SNAPSHOT` (latest `v1.2.0` → `1.3.0-SNAPSHOT`) | `maven-snapshots` |
| other branches | nothing (test only) | — |

- `Jenkinsfile`: `scalaClientVersion()` derives the version from `env.TAG_NAME` (release) or the latest `vX.Y.Z` git tag (next-minor SNAPSHOT), and always passes `-Dversion` to sbt. The Go lambda build/deploy still runs **only on `main`** — a tag is a library release, not a service deploy.
- `build.sbt`: local fallback is now `0.0.0-SNAPSHOT` (CI always injects the real version).
- `v`-prefixed tags match the house convention (pennsieve-go-core); the artifact version drops the `v`.

## To cut a release
Tag the commit `vX.Y.Z` and push it (or publish a GitHub Release from it). CI publishes `X.Y.Z` to `maven-releases`.

## Verified
Locally: bare `sbt` → `0.0.0-SNAPSHOT` (tests pass); `-Dversion=1.4.2` → `1.4.2`. Version logic traced for tag / main / no-tags cases.

## Note
Requires the Jenkins multibranch job to **build tags** (discover tag refs) for the release path to fire. If the email-service job only scans branches today, tag discovery needs enabling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)